### PR TITLE
Add debounce for power button

### DIFF
--- a/arch/arm/mach-aspeed/aspeed.c
+++ b/arch/arm/mach-aspeed/aspeed.c
@@ -141,6 +141,7 @@ static void __init do_barreleye_setup(void)
 
 	/* SCU setup */
 	writel(0x01C00000, AST_IO(AST_BASE_SCU | 0x88));
+	//To enable GPIOE0 pass through function debounce mode.
 	writel(0x010FFFFF, AST_IO(AST_BASE_SCU | 0xA8));
 	/*
 	 * Do read/modify/write on power gpio to prevent resetting power on
@@ -152,8 +153,10 @@ static void __init do_barreleye_setup(void)
 	writel(0xC738F20A, AST_IO(AST_BASE_GPIO | 0x24));
 	writel(0x0031FFAF, AST_IO(AST_BASE_GPIO | 0x80));
 	//debounce setting
+	//Select GPIO58 as debounce timer
 	writel(0x00000001, AST_IO(AST_BASE_GPIO | 0x48));
 	writel(0x00000001, AST_IO(AST_BASE_GPIO | 0x4C));
+	//After experiment, the suitable time is 20 ms.
 	writel(0x00075300, AST_IO(AST_BASE_GPIO | 0x58));
 }
 

--- a/arch/arm/mach-aspeed/aspeed.c
+++ b/arch/arm/mach-aspeed/aspeed.c
@@ -141,7 +141,7 @@ static void __init do_barreleye_setup(void)
 
 	/* SCU setup */
 	writel(0x01C00000, AST_IO(AST_BASE_SCU | 0x88));
-
+	writel(0x010FFFFF, AST_IO(AST_BASE_SCU | 0xA8));
 	/*
 	 * Do read/modify/write on power gpio to prevent resetting power on
 	 * reboot
@@ -151,6 +151,10 @@ static void __init do_barreleye_setup(void)
 	writel(reg, AST_IO(AST_BASE_GPIO | 0x20));
 	writel(0xC738F20A, AST_IO(AST_BASE_GPIO | 0x24));
 	writel(0x0031FFAF, AST_IO(AST_BASE_GPIO | 0x80));
+	//debounce setting
+	writel(0x00000001, AST_IO(AST_BASE_GPIO | 0x48));
+	writel(0x00000001, AST_IO(AST_BASE_GPIO | 0x4C));
+	writel(0x00075300, AST_IO(AST_BASE_GPIO | 0x58));
 }
 
 static void __init do_palmetto_setup(void)


### PR DESCRIPTION
This configures GPIOE0, which is BMC_PWBTN_IN_N, to be debounced. It
 uses timer 3 for 480000 cycles, which with a pclk of 24MHz is 20ms.

384MHz for H-PLL (HW strapping)
 PCLK=H-PLL/16=24MHz (SCU08, bit25:23)
 debounce timer value = debounce time / PCLK cycle time = 20ms*24000000/1000=480000(DEC)=0x75300(HEX)

Signed-off-by: Ken Liu ken.th.liu@foxconn.com
